### PR TITLE
Hide shorts category on search pages

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -38,6 +38,8 @@ youtube.com##ytd-reel-shelf-renderer.ytd-structured-description-content-renderer
 ! Remove empty spaces in grid
 youtube.com##ytd-rich-grid-row,#contents.ytd-rich-grid-row:style(display: contents !important)
 
+! Hide shorts category on search pages
+youtube.com##yt-chip-cloud-chip-renderer.yt-chip-cloud-renderer.style-scope:has-text(Shorts)
 
 !!! MOBILE !!!
 


### PR DESCRIPTION
Before:

![before_20240121_181744](https://github.com/gijsdev/ublock-hide-yt-shorts/assets/152305632/8d0cc572-a4a6-4ab9-8831-e13142345156)

After:

![after_20240121_181833](https://github.com/gijsdev/ublock-hide-yt-shorts/assets/152305632/eb91f0df-561b-4e90-b509-086a04500a71)
