### PR TITLE
Restore compability for YouTube in other languages

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -34,8 +34,8 @@ www.youtube.com##tp-yt-paper-tab:has(.tp-yt-paper-tab:has-text(Shorts))
 ! New style (2023-10)
 www.youtube.com##yt-tab-shape:has-text(/^Shorts$/)
 
-! Hide short remixes in video descriptions
-www.youtube.com##ytd-reel-shelf-renderer.ytd-structured-description-content-renderer:has-text(/^Shorts remixing this video$/i)
+! Hide short remixes in video descriptions and in suggestions beside the comments
+www.youtube.com##ytd-reel-shelf-renderer:has(#title:has-text(/(^| )Shorts.?Remix.*$/i))
 
 ! Hide shorts category on homepage and search pages
 www.youtube.com##yt-chip-cloud-chip-renderer:has(yt-formatted-string:has-text(/^Shorts$/i))
@@ -64,8 +64,8 @@ m.youtube.com##.single-column-browse-results-tabs>a:has-text(Shorts)
 ! New style (2023-10)
 m.youtube.com##yt-tab-shape:has-text(/^Shorts$/)
 
-! Hide short remixes in video descriptions
-m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/^Shorts remixing this video$/i))
+! Hide short remixes in video descriptions and in suggestions below the player
+m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts.?Remix.*$/i))
 
 ! Hide shorts category on homepage
 m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))

--- a/list.txt
+++ b/list.txt
@@ -1,7 +1,7 @@
 ! Title: Hide YouTube Shorts
 ! Description: Hide all traces of YouTube shorts videos on YouTube
-! Version: 1.8.0
-! Last modified: 2024-01-08 20:02
+! Version: 1.9.0
+! Last modified: 2024-02-17 11:55
 ! Expires: 2 weeks (update frequency)
 ! Homepage: https://github.com/gijsdev/ublock-hide-yt-shorts
 ! License: https://github.com/gijsdev/ublock-hide-yt-shorts/blob/master/LICENSE.md


### PR DESCRIPTION
Hi,

to my understanding, there is no requirement for these specific regex checks that were added in recently.

`www.youtube.com##ytd-reel-shelf-renderer` (and `m.youtube.com##ytm-reel-shelf-renderer`) by itself should - as the name implies - only blocks the rendering of the reel shelf, nothing else should be affected.

In addition to that, comparing against the hard coded string `Shorts remixing this video` only works, if you use YouTube in an English environment.

For example, the filter did not affect German YouTube which has another text displayed due to localization.

![20240218_213040](https://github.com/gijsdev/ublock-hide-yt-shorts/assets/152305632/fd60baa8-6719-4106-ab4c-ee63092109e3)

Feel free to correct me, if I'm wrong. :)
