### PR TITLE
Update list to work with new Shorts implementation

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -28,6 +28,10 @@ www.youtube.com##ytd-mini-guide-entry-renderer:has(.title:has-text(/^Shorts$/i))
 www.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytd-rich-section-renderer:has(#title:has-text(/(^| )Shorts( |$)/i))
 www.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytd-reel-shelf-renderer:has(.ytd-reel-shelf-renderer:has-text(/(^| )Shorts( |$)/i))
 
+! Hide shorts in 'special containers' on the home page
+www.youtube.com##.ytdRichGridGroupContents
+www.youtube.com##ytd-rich-grid-group.ytdRichGridGroupHost
+
 ! Hide shorts tab on channel pages`
 ! Old style
 www.youtube.com##tp-yt-paper-tab:has(.tp-yt-paper-tab:has-text(Shorts))


### PR DESCRIPTION
I'm not well-versed in uBO's syntax; these two rules are simply what I've found to work with uBO's element picker. Feel free to make any changes!

What it fixes:
![image](https://github.com/user-attachments/assets/541424d0-9816-41bf-b790-371491622a1d)