### PR TITLE
Add support for new YouTube Shorts grid shelf layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [uBlock Origin](https://github.com/gorhill/uBlock) filter list to hide all tra
 
 This filter list might work with other content blockers, but I haven't looked into that (yet).
 
-Copy the link below, go to uBlock Origin > Dashboard > Filters and paste the link underneath the 'Import...' heading:
+Copy the link below, go to uBlock Origin > Dashboard > Filter lists, scroll to the bottom, and paste the link underneath the 'Import...' heading:
 - [https://raw.githubusercontent.com/gijsdev/ublock-hide-yt-shorts/master/list.txt](ubo:subscribe?location=https://raw.githubusercontent.com/gijsdev/ublock-hide-yt-shorts/master/list.txt)
 
 ## License

--- a/list.txt
+++ b/list.txt
@@ -70,3 +70,8 @@ m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-at
 ! Hide shorts category on homepage
 m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
 
+! Hide shorts grid shelf sections (new layout)
+www.youtube.com##grid-shelf-view-model:has(h2:has-text(/^Shorts$/i))
+www.youtube.com##ytd-item-section-renderer:has(grid-shelf-view-model:has(h2:has-text(/^Shorts$/i)))
+! Hide shorts grid shelf by class (when it has Shorts title)
+www.youtube.com##.ytGridShelfViewModelHost:has(h2:has-text(/^Shorts$/i))

--- a/list.txt
+++ b/list.txt
@@ -1,7 +1,7 @@
 ! Title: Hide YouTube Shorts
 ! Description: Hide all traces of YouTube shorts videos on YouTube
-! Version: 1.10.0
-! Last modified: 2024-08-31 19:24
+! Version: 1.20.0
+! Last modified: 2025-06-27 12:24
 ! Expires: 2 weeks (update frequency)
 ! Homepage: https://github.com/gijsdev/ublock-hide-yt-shorts
 ! License: https://github.com/gijsdev/ublock-hide-yt-shorts/blob/master/LICENSE.md
@@ -40,6 +40,15 @@ www.youtube.com##ytd-reel-shelf-renderer:has(#title:has-text(/(^| )Shorts.?Remix
 ! Hide shorts category on homepage and search pages
 www.youtube.com##yt-chip-cloud-chip-renderer:has(yt-formatted-string:has-text(/^Shorts$/i))
 
+! Hide shorts grid on search results
+www.youtube.com##grid-shelf-view-model:has(h2:has-text(/^Shorts$/i))
+www.youtube.com##ytd-item-section-renderer:has(grid-shelf-view-model:has(h2:has-text(/^Shorts$/i)))
+www.youtube.com##.ytGridShelfViewModelHost:has(h2:has-text(/^Shorts$/i))
+
+! Hide shorts in 'special containers' on the home page
+www.youtube.com##.ytdRichGridGroupContents
+www.youtube.com##ytd-rich-grid-group.ytdRichGridGroupHost
+
 !!! MOBILE !!!
 
 ! Hide all videos in home feed containing the phrase "#shorts"
@@ -56,6 +65,7 @@ m.youtube.com##ytm-video-with-context-renderer:has([data-style="SHORTS"])
 
 ! Hide shorts sections except on history page
 m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-rich-section-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
+m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-rich-section-renderer:has(.yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
 m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-reel-shelf-renderer.item:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
 
 ! Hide shorts tab on channel pages
@@ -69,9 +79,3 @@ m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-at
 
 ! Hide shorts category on homepage
 m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
-
-! Hide shorts grid shelf sections (new layout)
-www.youtube.com##grid-shelf-view-model:has(h2:has-text(/^Shorts$/i))
-www.youtube.com##ytd-item-section-renderer:has(grid-shelf-view-model:has(h2:has-text(/^Shorts$/i)))
-! Hide shorts grid shelf by class (when it has Shorts title)
-www.youtube.com##.ytGridShelfViewModelHost:has(h2:has-text(/^Shorts$/i))

--- a/list.txt
+++ b/list.txt
@@ -44,6 +44,7 @@ www.youtube.com##yt-chip-cloud-chip-renderer:has(yt-formatted-string:has-text(/^
 www.youtube.com##grid-shelf-view-model:has(h2:has-text(/^Shorts$/i))
 www.youtube.com##ytd-item-section-renderer:has(grid-shelf-view-model:has(h2:has-text(/^Shorts$/i)))
 www.youtube.com##.ytGridShelfViewModelHost:has(h2:has-text(/^Shorts$/i))
+youtube.com##ytd-search ytd-item-section-renderer>#contents>:is(:not(ytd-video-renderer,yt-showing-results-for-renderer,[icon-name="promo-full-height:EMPTY_SEARCH"]),ytd-video-renderer:has([aria-label="Shorts"])),ytd-secondary-search-container-renderer
 
 ! Hide shorts in 'special containers' on the home page
 www.youtube.com##.ytdRichGridGroupContents


### PR DESCRIPTION
Adds filtering rules to block the new YouTube Shorts grid shelf layout that appears on homepage and search results. This layout uses different HTML structure with grid-shelf-view-model containers that weren't covered by existing filters.

Changes:
- Add rule to hide grid-shelf-view-model containers with "Shorts" title
- Add rule to hide ytd-item-section-renderer containing shorts grid shelves  
- Add rule to hide .ytGridShelfViewModelHost with "Shorts" header

The new rules use :has() selectors to specifically target shelves with "Shorts" in the title, avoiding overly broad blocking that could affect legitimate content. These filters complement existing rules by covering the updated DOM structure YouTube has deployed for shorts sections.

Fixes issue where shorts grid shelves were still visible despite existing filters being active.