### PR TITLE
Improve Shorts filters for mobile uBlock compatibility.

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -43,30 +43,45 @@ www.youtube.com##yt-chip-cloud-chip-renderer:has(yt-formatted-string:has-text(/^
 !!! MOBILE !!!
 
 ! Hide all videos in home feed containing the phrase "#shorts"
-www.youtube.com##ytm-rich-item-renderer:has(#video-title:has-text(/(^| )#Shorts?( |$)/i))
+! www.youtube.com##ytm-rich-item-renderer:has(#video-title:has-text(/(^| )#Shorts?( |$)/i))
 
 ! Hide all videos in subscription feed containing the phrase "#shorts"
-m.youtube.com##ytm-item-section-renderer:has(#video-title:has-text(/(^| )#Shorts?( |$)/i))
+! m.youtube.com##ytm-item-section-renderer:has(#video-title:has-text(/(^| )#Shorts?( |$)/i))
 
 ! Hide shorts button in the bottom navigation bar
-m.youtube.com##ytm-pivot-bar-item-renderer:has(.pivot-shorts)
+! m.youtube.com##ytm-pivot-bar-item-renderer:has(.pivot-shorts)
 
 ! Hide all videos with the shorts indicator on the thumbnail
-m.youtube.com##ytm-video-with-context-renderer:has([data-style="SHORTS"])
+! m.youtube.com##ytm-video-with-context-renderer:has([data-style="SHORTS"])
 
 ! Hide shorts sections except on history page
-m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-rich-section-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
-m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-reel-shelf-renderer.item:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
+! m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-rich-section-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
+! m.youtube.com##:matches-path(/^(?!\/feed\/history).*$/)ytm-reel-shelf-renderer.item:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts( |$)/i))
 
 ! Hide shorts tab on channel pages
 ! Old style
-m.youtube.com##.single-column-browse-results-tabs>a:has-text(Shorts)
+! m.youtube.com##.single-column-browse-results-tabs>a:has-text(Shorts)
 ! New style (2023-10)
-m.youtube.com##yt-tab-shape:has-text(/^Shorts$/)
+! m.youtube.com##yt-tab-shape:has-text(/^Shorts$/)
 
 ! Hide short remixes in video descriptions and in suggestions below the player
-m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts.?Remix.*$/i))
+! m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts.?Remix.*$/i))
 
 ! Hide shorts category on homepage
-m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
+! m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
 
+!!! MOBILE FILTERS FOR YOUTUBE (14-July-2025 Tested : Android 11 RKQ1.200826.002, 16 BP2A.250605.031.A2) !!!
+
+! Hide Shorts button in the bottom navigation bar (Bottom Tabs)
+m.youtube.com##ytm-pivot-bar-item-renderer:has(.pivot-shorts)
+
+! Hide Shorts sections on the homepage by matching title "Shorts"
+m.youtube.com##ytm-rich-section-renderer:has(h2:has-text(Shorts))
+
+! Hide all Shorts shelves (includes Shorts rows under videos and on channels)
+m.youtube.com##ytm-reel-shelf-renderer
+
+! Hide Shorts results in search/feed (entire video-with-context block)
+m.youtube.com##ytm-video-with-context-renderer:has(a[href^="/shorts/"])
+
+! Finished with YT-Shorts


### PR DESCRIPTION
### Description

This PR enhances Shorts filtering for mobile YouTube (`m.youtube.com`) using uBlock Origin.

- Adds additional cosmetic filters to effectively target Shorts content.
- Removes Shorts from:
  - Search results
  - Home feed
  - Channel pages
  - Shorts shelves and sections

### Tested on:
- **Pixel 7** (Android 16 – BP2A.250605.031.A2)
- **Redmi Note 10 Pro** (Android 11 – RKQ1.200826.002)
  > Note: Cosmetic filtering must be enabled in uBlock Origin settings for full effect.

---

### Screenshots

#### **Before : Shorts showing in feed**

<img width="539" height="863" alt="Screenshot from 2025-07-14 23-04-25" src="https://github.com/user-attachments/assets/895d4bee-22d8-4066-86c0-235222be9484" />

<img width="539" height="863" alt="Screenshot from 2025-07-14 23-06-06" src="https://github.com/user-attachments/assets/9e8b8133-3d2b-4aa0-80aa-9f3e2ed7deb0" />

#### **After : Shorts removed via uBlock filters**

<img width="539" height="863" alt="Screenshot from 2025-07-14 23-10-04" src="https://github.com/user-attachments/assets/91cfa21b-32cb-4242-b86e-76fbe64ff51d" />

<img width="539" height="863" alt="Screenshot from 2025-07-14 23-10-22" src="https://github.com/user-attachments/assets/0ccb731c-879c-4767-895b-7be855a800eb" />


