### PR TITLE
[Mobile] Hide Shorts category on homepage

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -72,7 +72,7 @@ m.youtube.com##yt-tab-shape:has-text(/^Shorts$/)
 m.youtube.com##ytm-reel-shelf-renderer:has(.reel-shelf-title-wrapper .yt-core-attributed-string:has-text(/(^| )Shorts.?Remix.*$/i))
 
 ! Hide shorts category on homepage
-m.youtube.com##ytm-chip-cloud-chip-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
+m.youtube.com##ytm-rich-section-renderer:has(.yt-core-attributed-string:has-text(/^Shorts$/i))
 
 ! Hide shorts sections on search page
 m.youtube.com##ytm-reel-shelf-renderer:has(ytm-shorts-lockup-view-model)


### PR DESCRIPTION
Closes: https://github.com/gijsdev/ublock-hide-yt-shorts/issues/66